### PR TITLE
Feature/blake endian fix

### DIFF
--- a/zinc-examples/blake_bit_endian_test/Zargo.toml
+++ b/zinc-examples/blake_bit_endian_test/Zargo.toml
@@ -1,0 +1,3 @@
+[circuit]
+name = "blake_bit_endian_test"
+version = "0.1.0"

--- a/zinc-examples/blake_bit_endian_test/src/main.zn
+++ b/zinc-examples/blake_bit_endian_test/src/main.zn
@@ -1,0 +1,42 @@
+//!
+//! The 'blake_bit_endian_test' main module.
+//!
+
+use std::crypto::blake2s; 
+
+const PREIMAGE_BYTES: u8 = 4; 
+const DIGEST_BYTES: u8 = 32;
+const BYTE_SIZE: u8 = 8; 
+
+fn main(preimage: u32) {
+    
+    let preimage_bits = std::convert::to_bits(preimage);
+
+    let mut preimage_bytes = [0; PREIMAGE_BYTES]; 
+
+    for i in 0..PREIMAGE_BYTES {
+        let mut bits = [false; BYTE_SIZE];
+        for j in 0..BYTE_SIZE {
+            bits[j] = preimage_bits[BYTE_SIZE * i + j]; 
+        }
+        preimage_bytes[i] = std::convert::from_bits_unsigned(bits); 
+    }
+
+    //Preimage bytes
+    dbg!("Preimage bytes: {}", preimage_bytes ); 
+
+    let digest_bits = blake2s(preimage_bits);
+
+    let mut digest_bytes = [0; DIGEST_BYTES]; 
+    for i in 0..DIGEST_BYTES {
+        let mut bits = [false; BYTE_SIZE];
+        for j in 0..BYTE_SIZE {
+            bits[j] = digest_bits[BYTE_SIZE * i + j]; 
+        }
+        digest_bytes[i] = std::convert::from_bits_unsigned(bits); 
+    }
+    
+    //Digest bytes
+    dbg!("Computed digest bytes: {}", digest_bytes );
+      
+}

--- a/zinc-tester/tests/std/crypto_blake2s_u248_to_u248.zn
+++ b/zinc-tester/tests/std/crypto_blake2s_u248_to_u248.zn
@@ -3,7 +3,7 @@
 //#     "input": {
 //#         "preimage": "42"
 //#     },
-//#     "expect": "0x6c06d59746757b9869e14d3ff163ded9c89934e64666be4204f68086cbb063"
+//#     "expect": "0xe22effe20573f1610ee1577504e9e9144cd7a5d7eaa8689d366c7bfc8a882a"
 //# } ] }
 
 use std::convert;

--- a/zinc-vm/src/stdlib/crypto/blake2s.rs
+++ b/zinc-vm/src/stdlib/crypto/blake2s.rs
@@ -25,6 +25,22 @@ impl Blake2s {
     }
 }
 
+// Implementation of Blake2s gadget for Zinc. 
+// It uses blake2s implementation of the franklin_crypto library.
+
+// IMPORTANT NOTE ABOUT THE GADGET: 
+// In its original format, the hash digest of the franklin_crypto library does 
+// not match with the original blake2 specification and with the BouncyCastle library. 
+// Both the original spec and the BouncyCastle requires a little-endian representation 
+// of **bytes** within the hash computation. And the same is for the franklin_crypto.
+// However, on top of that, franklin_crypto also requires little-endian ordering of 
+// **bits within each byte** due to the UInt32 object type used in the implementation.
+// UInt32 is a representation of 32 Boolean objects as an unsigned integer, where the
+// least significant bit is located in the first place. 
+
+// To overcome the mismatch between the franklin_crypto and the original spec, we added 
+// a function in our gadget, reverse_byte_bits(), which reverses the bit order within 
+// every byte before and after hashing operation.   
 impl<E: Engine> NativeFunction<E> for Blake2s {
     fn execute<CS: ConstraintSystem<E>>(
         &self,
@@ -34,8 +50,8 @@ impl<E: Engine> NativeFunction<E> for Blake2s {
         //reverse the bits of each byte of the input
         //for compatibility with Bouncy Castle
         fn reverse_byte_bits<T>(bits: &mut Vec<T>) {
-            for bytes in bits.chunks_mut(BYTE_LENGTH) {
-                bytes.reverse();
+            for byte_bits in bits.chunks_mut(BYTE_LENGTH) {
+                byte_bits.reverse();
             }
         }
 
@@ -50,12 +66,12 @@ impl<E: Engine> NativeFunction<E> for Blake2s {
         }
         bits.reverse();
 
-        //reverse preimage
+        //reverse preimage for compatibility with the original spec 
         reverse_byte_bits(&mut bits);
 
         let mut digest_bits = blake2s(cs.namespace(|| "blake2s"), &bits, b"12345678")?;
 
-        //reverse digest
+        //reverse digest for compatibility with the original spec
         reverse_byte_bits(&mut digest_bits);
 
         assert_eq!(digest_bits.len(), 256);


### PR DESCRIPTION
Update on the blake gadget to enable bit endianness on the Zinc side.
PR includes:

An auxiliary function in the blake gadget which enables the reversal of the bits within each byte both for preimage and for the digest.
An example to manually validate the new hash value.