### PR TITLE
Enable intermodule dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.vscode/
 
 # Rust build
+/target-*
 /target/
 /osxcross/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-compiler"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-MB-5"
 dependencies = [
  "colored",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
 name = "schnorr"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 dependencies = [
  "colored",
  "env_logger",
@@ -1074,7 +1074,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zargo"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 dependencies = [
  "env_logger",
  "failure",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-bytecode"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 dependencies = [
  "bincode",
  "colored",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-compiler"
-version = "0.1.5-ING-MB-5"
+version = "0.1.5-ING-5"
 dependencies = [
  "colored",
  "env_logger",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-tester"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 dependencies = [
  "colored",
  "failure",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-utils"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 dependencies = [
  "num-bigint",
  "num-traits 0.2.11",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-vm"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 dependencies = [
  "bellman_ce",
  "clap",

--- a/schnorr/Cargo.toml
+++ b/schnorr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schnorr"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 authors = ["Alexander Movchan <am@matterlabs.dev>"]
 edition = "2018"
 description = "The Zinc Schnorr signature generator"

--- a/zargo/Cargo.toml
+++ b/zargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zargo"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 authors = ["hedgar2017 <hedgar2017@gmail.com>"]
 edition = "2018"
 description = "The Zinc's circuit manager"

--- a/zinc-bytecode/Cargo.toml
+++ b/zinc-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-bytecode"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 authors = [
     "Alexander Movchan <am@matterlabs.dev>",
     "hedgar2017 <hedgar2017@gmail.com>",

--- a/zinc-compiler/Cargo.toml
+++ b/zinc-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-compiler"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-MB-5"
 authors = [
     "hedgar2017 <hedgar2017@gmail.com>",
     "Alexander Movchan <am@matterlabs.dev>",

--- a/zinc-compiler/Cargo.toml
+++ b/zinc-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-compiler"
-version = "0.1.5-ING-MB-5"
+version = "0.1.5-ING-5"
 authors = [
     "hedgar2017 <hedgar2017@gmail.com>",
     "Alexander Movchan <am@matterlabs.dev>",

--- a/zinc-compiler/src/file/mod.rs
+++ b/zinc-compiler/src/file/mod.rs
@@ -98,23 +98,15 @@ impl File {
             .parse(&self.code, Some(next_file_id))
             .map_err(|error| error.format(&lines))?;
 
-        let mut modules = Vec::<String>::new();
-        for statement in syntax_tree.statements.into_iter() {
-            match statement {
-                Statement::Mod(statement) => {
-                    modules.push(statement.identifier.name);
+        Ok(syntax_tree.statements
+            .into_iter()
+            .fold(Vec::new(), |mut modules, statement| {
+                if let Statement::Mod(s) = statement {
+                    modules.push(s.identifier.name);
                 }
-                Statement::Const(_) => { break; }
-                Statement::Type(_) => { break; }
-                Statement::Struct(_) => { break; }
-                Statement::Enum(_) => { break; }
-                Statement::Fn(_) => { break; }
-                Statement::Use(_) => { break; }
-                Statement::Impl(_) => { break; }
-                Statement::Empty(_) => { break; }
-            }
-        }
-        Ok(modules)
+                modules
+            })
+        )
     }
 }
 

--- a/zinc-compiler/src/file/mod.rs
+++ b/zinc-compiler/src/file/mod.rs
@@ -116,7 +116,7 @@ impl TryFrom<PathBuf> for File {
     fn try_from(path: PathBuf) -> Result<Self, Self::Error> {
         let mut file = ::std::fs::File::open(&path)
             .map_err(Error::Opening)
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| format!("{}: {}", error.to_string(), path.display()))?;
 
         let size = file
             .metadata()

--- a/zinc-compiler/src/file/mod.rs
+++ b/zinc-compiler/src/file/mod.rs
@@ -2,8 +2,6 @@
 //! The file reader.
 //!
 
-pub mod error;
-
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -19,13 +17,17 @@ use crate::semantic::analyzer::entry::Analyzer as EntryAnalyzer;
 use crate::semantic::analyzer::module::Analyzer as ModuleAnalyzer;
 use crate::semantic::scope::Scope;
 use crate::syntax::parser::Parser;
+use crate::syntax::tree::statement::local_mod::Statement;
 
 use self::error::Error;
 
+pub mod error;
+
 pub struct File {
-    path: PathBuf,
-    code: String,
+    pub path: PathBuf,
+    pub code: String,
 }
+
 
 lazy_static! {
     pub static ref INDEX: RwLock<Vec<PathBuf>> = RwLock::new(Vec::new());
@@ -60,6 +62,7 @@ impl File {
     pub fn try_into_module(
         self,
         bytecode: Rc<RefCell<Bytecode>>,
+        dependencies: HashMap<String, Rc<RefCell<Scope>>>,
     ) -> Result<Rc<RefCell<Scope>>, String> {
         let lines = self.code.lines().collect::<Vec<&str>>();
 
@@ -74,12 +77,44 @@ impl File {
             .map_err(|error| error.format(&lines))?;
 
         let (scope, intermediate) = ModuleAnalyzer::new()
-            .compile(syntax_tree)
+            .compile(syntax_tree, dependencies)
             .map_err(|error| error.format(&lines))?;
 
         intermediate.write_all_to_bytecode(bytecode);
 
         Ok(scope)
+    }
+
+    pub fn find_modules(self) -> Result<Vec<String>, String> {
+        let lines = self.code.lines().collect::<Vec<&str>>();
+
+        let next_file_id = INDEX.read().expect(crate::PANIC_MUTEX_SYNC).len();
+        INDEX
+            .write()
+            .expect(crate::PANIC_MUTEX_SYNC)
+            .push(self.path);
+
+        let syntax_tree = Parser::default()
+            .parse(&self.code, Some(next_file_id))
+            .map_err(|error| error.format(&lines))?;
+
+        let mut modules = Vec::<String>::new();
+        for statement in syntax_tree.statements.into_iter() {
+            match statement {
+                Statement::Mod(statement) => {
+                    modules.push(statement.identifier.name);
+                }
+                Statement::Const(_) => { break; }
+                Statement::Type(_) => { break; }
+                Statement::Struct(_) => { break; }
+                Statement::Enum(_) => { break; }
+                Statement::Fn(_) => { break; }
+                Statement::Use(_) => { break; }
+                Statement::Impl(_) => { break; }
+                Statement::Empty(_) => { break; }
+            }
+        }
+        Ok(modules)
     }
 }
 

--- a/zinc-compiler/src/main.rs
+++ b/zinc-compiler/src/main.rs
@@ -125,7 +125,7 @@ fn main() {
 //     mark n with a permanent mark
 //     add n to head of L
 fn visit(n: PathBuf, L: &mut VecDeque<PathBuf>, temp_marks: &mut Vec<PathBuf>) -> Result<(), Error> {
-    debug!("Visiting {}", n.display());
+    debug!("Visiting module {}", n.display());
     // if n has a permanent mark then
     //         return
     if L.contains(&n) {
@@ -140,7 +140,7 @@ fn visit(n: PathBuf, L: &mut VecDeque<PathBuf>, temp_marks: &mut Vec<PathBuf>) -
     debug!("TEMP MARK - CHECK : {}", n.display());
     if temp_marks.contains(&n) {
         debug!("TEMP MARK - CHECK : {}", "FOUND!");
-        return Err(Error::Compiler("Cyclic module dependencies are not supported".to_string()));
+        return Err(Error::Compiler(format!("Cyclic module dependencies are not supported. Found in: {}", n.display())));
     }
 
     // mark n with a temporary mark

--- a/zinc-compiler/src/main.rs
+++ b/zinc-compiler/src/main.rs
@@ -145,7 +145,6 @@ fn visit(n: PathBuf, L: &mut VecDeque<PathBuf>, temp_marks: &mut Vec<PathBuf>) -
 
     // mark n with a temporary mark
     debug!("TEMP MARK - ADD   : {}", n.display());
-    // temp_marks.insert(n.clone(), true);
     temp_marks.push(n.clone());
 
 

--- a/zinc-compiler/src/main.rs
+++ b/zinc-compiler/src/main.rs
@@ -158,13 +158,12 @@ fn visit(n: PathBuf, L: &mut VecDeque<PathBuf>, temp_marks: &mut Vec<PathBuf>) -
 
     debug!("Found # modules: {}", found_modules.len());
 
-    for m in found_modules.into_iter() {
+    found_modules.into_iter().try_for_each(|m| {
         // We assume that all modules are in the root path, next main.zn.
         // File name equals: <module name>.zn
         let module_path = n.with_file_name(m + ".zn");
         visit(module_path, L, temp_marks)
-            .expect("Compilation failed during module graph ordering");
-    }
+    }).expect("Compilation failed during module graph ordering");
 
     //     remove temporary mark from n
     debug!("TEMP MARK - REMOVE: {}", n.display());
@@ -206,13 +205,11 @@ fn main_inner(args: Arguments) -> Result<(), Error> {
     zinc_bytecode::logger::init_logger("znc", args.verbosity);
 
     let ordered_source_files = ordered_source_files(args.source_files)
-        .map_err(|e: Error| -> Error {
+        .map_err(|e| {
             Error::Compiler("Could not determine ordered source files: ".to_string())
         })?;
 
-    for file in ordered_source_files.clone().into_iter() {
-        debug!("Ordered file: {}", file.display())
-    }
+    ordered_source_files.iter().for_each(|file| debug!("Ordered file: {}", file.display()));
 
     let bytecode = Rc::new(RefCell::new(Bytecode::new()));
 

--- a/zinc-compiler/src/semantic/analyzer/module.rs
+++ b/zinc-compiler/src/semantic/analyzer/module.rs
@@ -9,8 +9,8 @@ use std::rc::Rc;
 use crate::error::Error as CompilerError;
 use crate::generator::Tree;
 use crate::semantic::analyzer::statement::Analyzer as StatementAnalyzer;
-use crate::semantic::scope::stack::Stack as ScopeStack;
 use crate::semantic::scope::Scope;
+use crate::semantic::scope::stack::Stack as ScopeStack;
 use crate::syntax::tree::Tree as SyntaxTree;
 
 ///
@@ -35,10 +35,14 @@ impl Analyzer {
         }
     }
 
-    pub fn compile(self, program: SyntaxTree) -> Result<(Rc<RefCell<Scope>>, Tree), CompilerError> {
+    pub fn compile(
+        self,
+        program: SyntaxTree,
+        dependencies: HashMap<String, Rc<RefCell<Scope>>>,
+    ) -> Result<(Rc<RefCell<Scope>>, Tree), CompilerError> {
         let mut intermediate = Tree::new();
 
-        let mut analyzer = StatementAnalyzer::new(self.scope_stack.top(), HashMap::new());
+        let mut analyzer = StatementAnalyzer::new(self.scope_stack.top(), dependencies);
         for statement in program.statements.into_iter() {
             if let Some(statement) = analyzer
                 .local_mod(statement)

--- a/zinc-compiler/src/semantic/tests.rs
+++ b/zinc-compiler/src/semantic/tests.rs
@@ -4,17 +4,17 @@
 
 #![allow(dead_code)]
 
-pub static PANIC_TEST_DATA: &str = "Test data is always valid";
-
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::error::Error;
+use crate::Parser;
 use crate::semantic::analyzer::entry::Analyzer as EntryAnalyzer;
 use crate::semantic::analyzer::module::Analyzer as ModuleAnalyzer;
 use crate::semantic::scope::Scope;
-use crate::Parser;
+
+pub static PANIC_TEST_DATA: &str = "Test data is always valid";
 
 static PANIC_SYNTAX_ERROR: &str = "Syntax errors must be eliminated at this point";
 
@@ -41,6 +41,7 @@ pub(crate) fn compile_module(input: &str) -> Result<Rc<RefCell<Scope>>, Error> {
         Parser::default()
             .parse(input, None)
             .expect(PANIC_SYNTAX_ERROR),
+        HashMap::new(),
     )?;
 
     Ok(scope)

--- a/zinc-tester/Cargo.toml
+++ b/zinc-tester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-tester"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 authors = ["hedgar2017 <hedgar2017@gmail.com>"]
 edition = "2018"
 description = "The Zinc integration tests runner"

--- a/zinc-utils/Cargo.toml
+++ b/zinc-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-utils"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 authors = [
     "hedgar2017 <hedgar2017@gmail.com>",
     "Alexander Movchan <am@matterlabs.dev>",

--- a/zinc-vm/Cargo.toml
+++ b/zinc-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-vm"
-version = "0.1.5-ING-4"
+version = "0.1.5-ING-5"
 authors = [
     "Alexander Movchan <am@matterlabs.dev>",
     "hedgar2017 <hedgar2017@gmail.com>",


### PR DESCRIPTION
This enables modules depending on other modules by topologically sorting source files based on their `mod` statements before starting compilation. This works, as long as there are no cyclic dependencies. If there are, compilation fails.

This PR badly needs review on efficiency and style by a Rustacean, since I lack knowledge of idiomatic constructs. Therefore very inelegant: unnecessary cloning because of moved values, and inelegant error handling with `expect`. 