### PR TITLE
Add pedersen multi input gadget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
 name = "schnorr"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 dependencies = [
  "colored",
  "env_logger",
@@ -1074,7 +1074,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zargo"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 dependencies = [
  "env_logger",
  "failure",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-bytecode"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 dependencies = [
  "bincode",
  "colored",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-compiler"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 dependencies = [
  "colored",
  "env_logger",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-tester"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 dependencies = [
  "colored",
  "failure",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-utils"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 dependencies = [
  "num-bigint",
  "num-traits 0.2.11",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "zinc-vm"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 dependencies = [
  "bellman_ce",
  "clap",

--- a/schnorr/Cargo.toml
+++ b/schnorr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schnorr"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 authors = ["Alexander Movchan <am@matterlabs.dev>"]
 edition = "2018"
 description = "The Zinc Schnorr signature generator"

--- a/zargo/Cargo.toml
+++ b/zargo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zargo"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 authors = ["hedgar2017 <hedgar2017@gmail.com>"]
 edition = "2018"
 description = "The Zinc's circuit manager"

--- a/zinc-bytecode/Cargo.toml
+++ b/zinc-bytecode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-bytecode"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 authors = [
     "Alexander Movchan <am@matterlabs.dev>",
     "hedgar2017 <hedgar2017@gmail.com>",

--- a/zinc-bytecode/src/builtins.rs
+++ b/zinc-bytecode/src/builtins.rs
@@ -17,4 +17,5 @@ pub enum BuiltinIdentifier {
     FieldInverse,
     CryptoBlake2s,
     CryptoBlake2sMultiInput,
+    CryptoPedersenMultiInput,
 }

--- a/zinc-compiler/Cargo.toml
+++ b/zinc-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-compiler"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 authors = [
     "hedgar2017 <hedgar2017@gmail.com>",
     "Alexander Movchan <am@matterlabs.dev>",

--- a/zinc-compiler/src/semantic/element/type/function/stdlib/crypto_pedersen_multi_input.rs
+++ b/zinc-compiler/src/semantic/element/type/function/stdlib/crypto_pedersen_multi_input.rs
@@ -1,0 +1,155 @@
+//!
+//! The semantic analyzer standard library `std::crypto::blake2s` function element.
+//!
+
+use std::fmt;
+use std::ops::Deref;
+
+use zinc_bytecode::builtins::BuiltinIdentifier;
+
+use crate::semantic::element::r#type::function::error::Error;
+use crate::semantic::element::r#type::Type;
+use crate::semantic::element::Element;
+
+#[derive(Debug, Clone)]
+pub struct Function {
+    builtin_identifier: BuiltinIdentifier,
+    identifier: &'static str,
+    return_type: Box<Type>,
+}
+
+impl Function {
+    pub const ARGUMENT_INDEX_PREIMAGE1: usize = 0;
+    pub const ARGUMENT_INDEX_PREIMAGE2: usize = 1;
+    pub const ARGUMENT_COUNT: usize = 2;
+
+    pub fn new(builtin_identifier: BuiltinIdentifier) -> Self {
+        Self {
+            builtin_identifier,
+            identifier: "pedersen_multi_input",
+            return_type: Box::new(Type::tuple(vec![Type::field(), Type::field()])),
+        }
+    }
+
+    pub fn identifier(&self) -> &'static str {
+        self.identifier
+    }
+
+    pub fn builtin_identifier(&self) -> BuiltinIdentifier {
+        self.builtin_identifier
+    }
+
+    pub fn call(self, actual_elements: Vec<Element>) -> Result<Type, Error> {
+        let mut actual_params = Vec::with_capacity(actual_elements.len());
+        for (index, element) in actual_elements.into_iter().enumerate() {
+            let r#type = match element {
+                Element::Value(value) => value.r#type(),
+                Element::Constant(constant) => constant.r#type(),
+                element => {
+                    return Err(Error::argument_not_evaluable(
+                        self.identifier.to_owned(),
+                        index + 1,
+                        element.to_string(),
+                    ))
+                }
+            };
+            actual_params.push(r#type);
+        }
+
+        match actual_params.get(Self::ARGUMENT_INDEX_PREIMAGE1) {
+            Some(Type::Array { r#type, size }) => match (r#type.deref(), *size) {
+                (Type::Boolean, size)
+                    if 0 < size && size <= crate::LIMIT_PEDERSEN_HASH_INPUT_BITS => {}
+                (r#type, size) => {
+                    return Err(Error::argument_type(
+                        self.identifier.to_owned(),
+                        "preimage1".to_owned(),
+                        Self::ARGUMENT_INDEX_PREIMAGE1 + 1,
+                        format!(
+                            "[bool; N], 0 < N <= {}",
+                            crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+                        ),
+                        format!("[{}; {}]", r#type, size),
+                    ))
+                }
+            },
+            Some(r#type) => {
+                return Err(Error::argument_type(
+                    self.identifier.to_owned(),
+                    "preimage1".to_owned(),
+                    Self::ARGUMENT_INDEX_PREIMAGE1 + 1,
+                    format!(
+                        "[bool; N], 0 < N <= {}",
+                        crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+                    ),
+                    r#type.to_string(),
+                ))
+            }
+            None => {
+                return Err(Error::argument_count(
+                    self.identifier.to_owned(),
+                    Self::ARGUMENT_COUNT,
+                    actual_params.len(),
+                ))
+            }
+        }
+
+        match actual_params.get(Self::ARGUMENT_INDEX_PREIMAGE2) {
+            Some(Type::Array { r#type, size }) => match (r#type.deref(), *size) {
+                (Type::Boolean, size)
+                    if 0 < size && size <= crate::LIMIT_PEDERSEN_HASH_INPUT_BITS => {}
+                (r#type, size) => {
+                    return Err(Error::argument_type(
+                        self.identifier.to_owned(),
+                        "preimage2".to_owned(),
+                        Self::ARGUMENT_INDEX_PREIMAGE2 + 1,
+                        format!(
+                            "[bool; N], 0 < N <= {}",
+                            crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+                        ),
+                        format!("[{}; {}]", r#type, size),
+                    ))
+                }
+            },
+            Some(r#type) => {
+                return Err(Error::argument_type(
+                    self.identifier.to_owned(),
+                    "preimage2".to_owned(),
+                    Self::ARGUMENT_INDEX_PREIMAGE2 + 1,
+                    format!(
+                        "[bool; N], 0 < N <= {}",
+                        crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+                    ),
+                    r#type.to_string(),
+                ))
+            }
+            None => {
+                return Err(Error::argument_count(
+                    self.identifier.to_owned(),
+                    Self::ARGUMENT_COUNT,
+                    actual_params.len(),
+                ))
+            }
+        }
+
+        if actual_params.len() > Self::ARGUMENT_COUNT {
+            return Err(Error::argument_count(
+                self.identifier.to_owned(),
+                Self::ARGUMENT_COUNT,
+                actual_params.len(),
+            ));
+        }
+
+        Ok(*self.return_type)
+    }
+}
+
+impl fmt::Display for Function {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "fn std::crypto::{}(preimage1: [bool: N], preimage2:[bool: N]) -> {}",
+            self.identifier, self.return_type,
+        )
+    }
+}

--- a/zinc-compiler/src/semantic/element/type/function/stdlib/mod.rs
+++ b/zinc-compiler/src/semantic/element/type/function/stdlib/mod.rs
@@ -14,6 +14,7 @@ pub mod convert_to_bits;
 pub mod crypto_blake2s;
 pub mod crypto_blake2s_multi_input;
 pub mod crypto_pedersen;
+pub mod crypto_pedersen_multi_input;
 pub mod crypto_schnorr_signature_verify;
 pub mod crypto_sha256;
 pub mod error;
@@ -37,6 +38,7 @@ use self::convert_to_bits::Function as ToBitsFunction;
 use self::crypto_blake2s::Function as Blake2sFunction;
 use self::crypto_blake2s_multi_input::Function as Blake2sMultiInputFunction;
 use self::crypto_pedersen::Function as PedersenFunction;
+use self::crypto_pedersen_multi_input::Function as PedersenMultiInputFunction;
 use self::crypto_schnorr_signature_verify::Function as SchnorrSignatureVerifyFunction;
 use self::crypto_sha256::Function as Sha256Function;
 use self::ff_invert::Function as FfInvertFunction;
@@ -45,6 +47,7 @@ use self::ff_invert::Function as FfInvertFunction;
 pub enum Function {
     CryptoSha256(Sha256Function),
     CryptoPedersen(PedersenFunction),
+    CryptoPedersenMultiInput(PedersenMultiInputFunction),
     CryptoSchnorrSignatureVerify(SchnorrSignatureVerifyFunction),
     CryptoBlake2s(Blake2sFunction),
     CryptoBlake2sMultiInput(Blake2sMultiInputFunction),
@@ -67,6 +70,9 @@ impl Function {
             BuiltinIdentifier::CryptoSha256 => Self::CryptoSha256(Sha256Function::new(identifier)),
             BuiltinIdentifier::CryptoPedersen => {
                 Self::CryptoPedersen(PedersenFunction::new(identifier))
+            }
+            BuiltinIdentifier::CryptoPedersenMultiInput => {
+                Self::CryptoPedersenMultiInput(PedersenMultiInputFunction::new(identifier))
             }
             BuiltinIdentifier::CryptoSchnorrSignatureVerify => {
                 Self::CryptoSchnorrSignatureVerify(SchnorrSignatureVerifyFunction::new(identifier))
@@ -105,6 +111,7 @@ impl Function {
         match self {
             Self::CryptoSha256(inner) => inner.call(elements),
             Self::CryptoPedersen(inner) => inner.call(elements),
+            Self::CryptoPedersenMultiInput(inner) => inner.call(elements),
             Self::CryptoSchnorrSignatureVerify(inner) => inner.call(elements),
             Self::CryptoBlake2s(inner) => inner.call(elements),
             Self::CryptoBlake2sMultiInput(inner) => inner.call(elements),
@@ -126,6 +133,7 @@ impl Function {
         match self {
             Self::CryptoSha256(inner) => inner.identifier(),
             Self::CryptoPedersen(inner) => inner.identifier(),
+            Self::CryptoPedersenMultiInput(inner) => inner.identifier(),
             Self::CryptoSchnorrSignatureVerify(inner) => inner.identifier(),
             Self::CryptoBlake2s(inner) => inner.identifier(),
             Self::CryptoBlake2sMultiInput(inner) => inner.identifier(),
@@ -147,6 +155,7 @@ impl Function {
         match self {
             Self::CryptoSha256(inner) => inner.builtin_identifier(),
             Self::CryptoPedersen(inner) => inner.builtin_identifier(),
+            Self::CryptoPedersenMultiInput(inner) => inner.builtin_identifier(),
             Self::CryptoSchnorrSignatureVerify(inner) => inner.builtin_identifier(),
             Self::CryptoBlake2s(inner) => inner.builtin_identifier(),
             Self::CryptoBlake2sMultiInput(inner) => inner.builtin_identifier(),
@@ -170,6 +179,7 @@ impl fmt::Display for Function {
         match self {
             Self::CryptoSha256(inner) => write!(f, "{}", inner),
             Self::CryptoPedersen(inner) => write!(f, "{}", inner),
+            Self::CryptoPedersenMultiInput(inner) => write!(f, "{}", inner),
             Self::CryptoSchnorrSignatureVerify(inner) => write!(f, "{}", inner),
             Self::CryptoBlake2s(inner) => write!(f, "{}", inner),
             Self::CryptoBlake2sMultiInput(inner) => write!(f, "{}", inner),

--- a/zinc-compiler/src/semantic/element/type/function/stdlib/tests.rs
+++ b/zinc-compiler/src/semantic/element/type/function/stdlib/tests.rs
@@ -23,6 +23,7 @@ use crate::semantic::element::r#type::function::stdlib::convert_to_bits::Functio
 use crate::semantic::element::r#type::function::stdlib::crypto_blake2s::Function as CryptoBlake2sFunction;
 use crate::semantic::element::r#type::function::stdlib::crypto_blake2s_multi_input::Function as CryptoBlake2sMultiInputFunction;
 use crate::semantic::element::r#type::function::stdlib::crypto_pedersen::Function as CryptoPedersenFunction;
+use crate::semantic::element::r#type::function::stdlib::crypto_pedersen_multi_input::Function as CryptoPedersenMultiInputFunction;
 use crate::semantic::element::r#type::function::stdlib::crypto_schnorr_signature_verify::Function as CryptoSchnorrSignatureVerifyFunction;
 use crate::semantic::element::r#type::function::stdlib::crypto_sha256::Function as CryptoSha256Function;
 use crate::semantic::element::r#type::function::stdlib::error::Error as StandardLibraryFunctionTypeError;
@@ -259,6 +260,212 @@ fn main() {
             "pedersen".to_owned(),
             "preimage".to_owned(),
             CryptoPedersenFunction::ARGUMENT_INDEX_PREIMAGE + 1,
+            format!(
+                "[bool; N], 0 < N <= {}",
+                crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+            ),
+            Type::array(Type::boolean(), crate::LIMIT_PEDERSEN_HASH_INPUT_BITS + 1).to_string(),
+        ))),
+    )));
+
+    let result = crate::semantic::tests::compile_entry(input);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn error_crypto_pedersen_multi_input_argument_count_lesser() {
+    let input = r#"
+fn main() {
+    std::crypto::pedersen_multi_input();
+}
+"#;
+
+    let expected = Err(Error::Semantic(SemanticError::Element(
+        Location::new(3, 38),
+        ElementError::Type(TypeError::Function(FunctionTypeError::argument_count(
+            "pedersen_multi_input".to_owned(),
+            CryptoPedersenMultiInputFunction::ARGUMENT_COUNT,
+            CryptoPedersenMultiInputFunction::ARGUMENT_COUNT - 2,
+        ))),
+    )));
+
+    let result = crate::semantic::tests::compile_entry(input);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn error_crypto_pedersen_multi_input_argument_count_greater() {
+    let input = r#"
+fn main() {
+    std::crypto::pedersen_multi_input([true; 8], [true; 8], 42);
+}
+"#;
+
+    let expected = Err(Error::Semantic(SemanticError::Element(
+        Location::new(3, 38),
+        ElementError::Type(TypeError::Function(FunctionTypeError::argument_count(
+            "pedersen_multi_input".to_owned(),
+            CryptoPedersenMultiInputFunction::ARGUMENT_COUNT,
+            CryptoPedersenMultiInputFunction::ARGUMENT_COUNT + 1,
+        ))),
+    )));
+
+    let result = crate::semantic::tests::compile_entry(input);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn error_crypto_pedersen_multi_input_argument_1_preimage_expected_bit_array() {
+    let input = r#"
+fn main() {
+    std::crypto::pedersen_multi_input(42, [true;8]);
+}
+"#;
+
+    let expected = Err(Error::Semantic(SemanticError::Element(
+        Location::new(3, 38),
+        ElementError::Type(TypeError::Function(FunctionTypeError::argument_type(
+            "pedersen_multi_input".to_owned(),
+            "preimage1".to_owned(),
+            CryptoPedersenMultiInputFunction::ARGUMENT_INDEX_PREIMAGE1 + 1,
+            format!(
+                "[bool; N], 0 < N <= {}",
+                crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+            ),
+            Type::integer_unsigned(crate::BITLENGTH_BYTE).to_string(),
+        ))),
+    )));
+
+    let result = crate::semantic::tests::compile_entry(input);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn error_crypto_pedersen_multi_input_argument_2_preimage_expected_bit_array() {
+    let input = r#"
+fn main() {
+    std::crypto::pedersen_multi_input([true;8], 42);
+}
+"#;
+
+    let expected = Err(Error::Semantic(SemanticError::Element(
+        Location::new(3, 38),
+        ElementError::Type(TypeError::Function(FunctionTypeError::argument_type(
+            "pedersen_multi_input".to_owned(),
+            "preimage2".to_owned(),
+            CryptoPedersenMultiInputFunction::ARGUMENT_INDEX_PREIMAGE2 + 1,
+            format!(
+                "[bool; N], 0 < N <= {}",
+                crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+            ),
+            Type::integer_unsigned(crate::BITLENGTH_BYTE).to_string(),
+        ))),
+    )));
+
+    let result = crate::semantic::tests::compile_entry(input);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn error_crypto_pedersen_multi_input_argument_1_preimage_expected_bit_array_not_empty() {
+    let input = r#"
+fn main() {
+    std::crypto::pedersen_multi_input([true; 0], [true; 8]);
+}
+"#;
+
+    let expected = Err(Error::Semantic(SemanticError::Element(
+        Location::new(3, 38),
+        ElementError::Type(TypeError::Function(FunctionTypeError::argument_type(
+            "pedersen_multi_input".to_owned(),
+            "preimage1".to_owned(),
+            CryptoPedersenMultiInputFunction::ARGUMENT_INDEX_PREIMAGE1 + 1,
+            format!(
+                "[bool; N], 0 < N <= {}",
+                crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+            ),
+            Type::array(Type::boolean(), 0).to_string(),
+        ))),
+    )));
+
+    let result = crate::semantic::tests::compile_entry(input);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn error_crypto_pedersen_multi_input_argument_2_preimage_expected_bit_array_not_empty() {
+    let input = r#"
+fn main() {
+    std::crypto::pedersen_multi_input([true; 8], [true; 0]);
+}
+"#;
+
+    let expected = Err(Error::Semantic(SemanticError::Element(
+        Location::new(3, 38),
+        ElementError::Type(TypeError::Function(FunctionTypeError::argument_type(
+            "pedersen_multi_input".to_owned(),
+            "preimage2".to_owned(),
+            CryptoPedersenMultiInputFunction::ARGUMENT_INDEX_PREIMAGE2 + 1,
+            format!(
+                "[bool; N], 0 < N <= {}",
+                crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+            ),
+            Type::array(Type::boolean(), 0).to_string(),
+        ))),
+    )));
+
+    let result = crate::semantic::tests::compile_entry(input);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn error_crypto_pedersen_multi_input_argument_1_preimage_expected_bit_array_size_limit() {
+    let input = r#"
+fn main() {
+    std::crypto::pedersen_multi_input([true; 513], [true; 8]);
+}
+"#;
+
+    let expected = Err(Error::Semantic(SemanticError::Element(
+        Location::new(3, 38),
+        ElementError::Type(TypeError::Function(FunctionTypeError::argument_type(
+            "pedersen_multi_input".to_owned(),
+            "preimage1".to_owned(),
+            CryptoPedersenMultiInputFunction::ARGUMENT_INDEX_PREIMAGE1 + 1,
+            format!(
+                "[bool; N], 0 < N <= {}",
+                crate::LIMIT_PEDERSEN_HASH_INPUT_BITS
+            ),
+            Type::array(Type::boolean(), crate::LIMIT_PEDERSEN_HASH_INPUT_BITS + 1).to_string(),
+        ))),
+    )));
+
+    let result = crate::semantic::tests::compile_entry(input);
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn error_crypto_pedersen_multi_input_argument_2_preimage_expected_bit_array_size_limit() {
+    let input = r#"
+fn main() {
+    std::crypto::pedersen_multi_input([true; 8], [true; 513]);
+}
+"#;
+
+    let expected = Err(Error::Semantic(SemanticError::Element(
+        Location::new(3, 38),
+        ElementError::Type(TypeError::Function(FunctionTypeError::argument_type(
+            "pedersen_multi_input".to_owned(),
+            "preimage2".to_owned(),
+            CryptoPedersenMultiInputFunction::ARGUMENT_INDEX_PREIMAGE2 + 1,
             format!(
                 "[bool; N], 0 < N <= {}",
                 crate::LIMIT_PEDERSEN_HASH_INPUT_BITS

--- a/zinc-compiler/src/semantic/scope/builtin.rs
+++ b/zinc-compiler/src/semantic/scope/builtin.rs
@@ -32,6 +32,8 @@ impl BuiltInItems {
         let mut std_crypto_scope = Scope::default();
         let std_crypto_sha256 = FunctionType::new_std(BuiltinIdentifier::CryptoSha256);
         let std_crypto_pedersen = FunctionType::new_std(BuiltinIdentifier::CryptoPedersen);
+        let std_crypto_pedersen_multi_input =
+            FunctionType::new_std(BuiltinIdentifier::CryptoPedersenMultiInput);
         let std_crypto_blake2s = FunctionType::new_std(BuiltinIdentifier::CryptoBlake2s);
         let std_crypto_blake2s_multi_input =
             FunctionType::new_std(BuiltinIdentifier::CryptoBlake2sMultiInput);
@@ -100,6 +102,13 @@ impl BuiltInItems {
             std_crypto_pedersen.identifier(),
             ScopeItem::new(
                 ScopeItemVariant::Type(Type::Function(std_crypto_pedersen)),
+                None,
+            ),
+        );
+        std_crypto_scope.items.insert(
+            std_crypto_pedersen_multi_input.identifier(),
+            ScopeItem::new(
+                ScopeItemVariant::Type(Type::Function(std_crypto_pedersen_multi_input)),
                 None,
             ),
         );

--- a/zinc-examples/pedersen_multi_input/Zargo.toml
+++ b/zinc-examples/pedersen_multi_input/Zargo.toml
@@ -1,0 +1,3 @@
+[circuit]
+name = "pedersen_multi_input"
+version = "0.1.0"

--- a/zinc-examples/pedersen_multi_input/src/main.zn
+++ b/zinc-examples/pedersen_multi_input/src/main.zn
@@ -1,0 +1,65 @@
+//!
+//! The 'pedersen_multi_input' main module.
+//!
+
+use std::crypto::pedersen;
+use std::crypto::pedersen_multi_input;
+use std::convert::to_bits;
+use std::convert::from_bits_unsigned;
+use std::array::pad;
+
+const INT32_BITS:u8 = 32; 
+const DIGEST_BYTES:u8 = 32;
+const BYTE_SIZE:u8 = 8; 
+
+fn main(preimage1: u32, preimage2:u32) -> bool {
+    
+    let preimage_bits_1: [bool; INT32_BITS] = to_bits(preimage1);
+    let preimage_bits_2: [bool; INT32_BITS] = to_bits(preimage2);
+    
+    //multi input digest
+    let digest_multi_input = pedersen_multi_input(preimage_bits_1, preimage_bits_2);
+    //Digest
+    dbg!("Digest multi input: {}", digest_multi_input);
+
+    //Bytes
+    let digest_bits_multi_input = pad(to_bits(digest_multi_input.0), 256, false); 
+        let mut digest_bytes_multi_input = [0; DIGEST_BYTES];   
+    for i in 0..DIGEST_BYTES {
+        let mut bits = [false; BYTE_SIZE];
+        for j in 0..BYTE_SIZE {
+            bits[j] = digest_bits_multi_input[BYTE_SIZE * i + j]; 
+        }
+        digest_bytes_multi_input[i] = from_bits_unsigned(bits); 
+    }
+
+    //Concatenated digest
+    let mut preimage_bits_concatenated : [bool; 2 * INT32_BITS] = [false; 2 * INT32_BITS];
+    preimage_bits_concatenated[0..INT32_BITS] = preimage_bits_1;
+    preimage_bits_concatenated[INT32_BITS..(2* INT32_BITS)] = preimage_bits_2; 
+
+    let digest_concatenated = pedersen(preimage_bits_concatenated);
+    //Digest 
+    dbg!("Digest concatenated: {}", digest_concatenated);
+    
+    //Bytes
+    let digest_bits_concatenated = pad(to_bits(digest_concatenated.0), 256, false); 
+    let mut digest_bytes_concatenated= [0; DIGEST_BYTES];   
+    for i in 0..DIGEST_BYTES {
+        let mut bits = [false; BYTE_SIZE];
+        for j in 0..BYTE_SIZE {
+            bits[j] = digest_bits_concatenated[BYTE_SIZE * i + j]; 
+        }
+        digest_bytes_concatenated[i] = from_bits_unsigned(bits); 
+    }
+
+    //Comparison
+    let mut isEqual = true; 
+    for i in 0..DIGEST_BYTES {
+        if(digest_bytes_multi_input[i] != digest_bytes_concatenated[i]){
+            isEqual = false; 
+        }
+    }
+
+    isEqual
+}

--- a/zinc-tester/Cargo.toml
+++ b/zinc-tester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-tester"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 authors = ["hedgar2017 <hedgar2017@gmail.com>"]
 edition = "2018"
 description = "The Zinc integration tests runner"

--- a/zinc-tester/tests/std/crypto_pedersen_multi_input.zn
+++ b/zinc-tester/tests/std/crypto_pedersen_multi_input.zn
@@ -8,32 +8,40 @@
 //# } ] }
 
 use std::convert::to_bits;
-use std::crypto::blake2s;
-use std::crypto::blake2s_multi_input;
+use std::crypto::pedersen;
+use std::crypto::pedersen_multi_input;
 
-const BLAKE2S_HASH_SIZE: u64 = 256;
+const PEDERSEN_HASH_SIZE: u64 = 254;
 const INT32_BITS:u8 = 32; 
 
 fn main(preimage1: u32, preimage2:u32) -> bool {
+    
     let preimage_bits_1: [bool; INT32_BITS] = to_bits(preimage1);
     let preimage_bits_2: [bool; INT32_BITS] = to_bits(preimage2);
     
     //multi input digest
-    let digest_bits_multi_input = blake2s_multi_input(preimage_bits_1, preimage_bits_2);
+    let digest_multi_input = pedersen_multi_input(preimage_bits_1, preimage_bits_2);
+
+    //Bytes
+    let digest_bits_multi_input = std::convert::to_bits(digest_multi_input.0); 
 
     //Concatenated digest
     let mut preimage_bits_concatenated : [bool; 2 * INT32_BITS] = [false; 2 * INT32_BITS];
     preimage_bits_concatenated[0..INT32_BITS] = preimage_bits_1;
     preimage_bits_concatenated[INT32_BITS..(2* INT32_BITS)] = preimage_bits_2; 
 
-    let digest_bits_concatenated = blake2s(preimage_bits_concatenated);
+    let digest_concatenated = pedersen(preimage_bits_concatenated);
 
-    //check
+    //Bytes
+    let digest_bits_concatenated = std::convert::to_bits(digest_concatenated.0); 
+
+    //Comparison
     let mut isEqual = true; 
-    for i in 0..BLAKE2S_HASH_SIZE {
+    for i in 0..PEDERSEN_HASH_SIZE {
         if(digest_bits_multi_input[i] != digest_bits_concatenated[i]){
             isEqual = false; 
         }
     }
+
     isEqual
 }

--- a/zinc-utils/Cargo.toml
+++ b/zinc-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-utils"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 authors = [
     "hedgar2017 <hedgar2017@gmail.com>",
     "Alexander Movchan <am@matterlabs.dev>",

--- a/zinc-vm/Cargo.toml
+++ b/zinc-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zinc-vm"
-version = "0.1.5-ING-6"
+version = "0.1.5-ING-7"
 authors = [
     "Alexander Movchan <am@matterlabs.dev>",
     "hedgar2017 <hedgar2017@gmail.com>",

--- a/zinc-vm/src/instructions/call_builtin.rs
+++ b/zinc-vm/src/instructions/call_builtin.rs
@@ -31,6 +31,9 @@ where
             BuiltinIdentifier::CryptoPedersen => {
                 vm.call_native(stdlib::crypto::Pedersen::new(self.inputs_count)?)
             }
+            BuiltinIdentifier::CryptoPedersenMultiInput => {
+                vm.call_native(stdlib::crypto::PedersenMultiInput::new(self.inputs_count)?)
+            }
             BuiltinIdentifier::ToBits => vm.call_native(stdlib::bits::ToBits),
             BuiltinIdentifier::UnsignedFromBits => {
                 vm.call_native(stdlib::bits::UnsignedFromBits::new(self.inputs_count))

--- a/zinc-vm/src/stdlib/crypto/mod.rs
+++ b/zinc-vm/src/stdlib/crypto/mod.rs
@@ -12,3 +12,6 @@ pub use sha256::*;
 
 mod pedersen;
 pub use pedersen::*;
+
+mod pedersen_multi_input;
+pub use pedersen_multi_input::*;

--- a/zinc-vm/src/stdlib/crypto/pedersen_multi_input.rs
+++ b/zinc-vm/src/stdlib/crypto/pedersen_multi_input.rs
@@ -1,0 +1,47 @@
+use crate::core::EvaluationStack;
+use crate::gadgets::Scalar;
+use crate::stdlib::NativeFunction;
+use crate::{Engine, Result};
+use bellman::ConstraintSystem;
+use franklin_crypto::circuit::pedersen_hash::{pedersen_hash, Personalization};
+
+pub struct PedersenMultiInput {
+    message_length: usize,
+}
+
+impl PedersenMultiInput {
+    pub fn new(message_length: usize) -> Result<Self> {
+        Ok(Self { message_length })
+    }
+}
+
+impl<E: Engine> NativeFunction<E> for PedersenMultiInput {
+    fn execute<CS: ConstraintSystem<E>>(
+        &self,
+        mut cs: CS,
+        stack: &mut EvaluationStack<E>,
+    ) -> Result {
+        let mut bits = Vec::new();
+        for i in 0..self.message_length {
+            let bit = stack
+                .pop()?
+                .value()?
+                .to_boolean(cs.namespace(|| format!("bit {}", i)))?;
+
+            bits.push(bit);
+        }
+        bits.reverse();
+
+        let digest = pedersen_hash(
+            cs,
+            Personalization::NoteCommitment,
+            bits.as_slice(),
+            E::jubjub_params(),
+        )?;
+
+        stack.push(Scalar::from(digest.get_x()).into())?;
+        stack.push(Scalar::from(digest.get_y()).into())?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Implement a new gadget for Pedersen hash that enables multiple inputs (currently two).