### PR TITLE
Only run release workflow when a tag is pushed and add push workflow

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,0 +1,30 @@
+name: Build and test
+
+on:
+  push:
+    branches:
+      - ing-fork
+  pull_request:
+    branches:
+      - ing-fork
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build project
+        run: |
+          cargo build
+
+      - name: Run unit tests
+        run: |
+          cargo test
+
+      - name: Run zinc-tester
+        run: |
+          target/debug/zinc-tester

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 on:
-  create:
-    # Sequence of patterns matched against refs/tags
+  push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 


### PR DESCRIPTION
This PR fixes the release workflow, and introduces a new workflow to run all tests for pull-requests.